### PR TITLE
Add encoding parameter to getTweetLength()

### DIFF
--- a/lib/Twitter/Validation.php
+++ b/lib/Twitter/Validation.php
@@ -306,11 +306,11 @@ class Twitter_Validation extends Twitter_Regex {
    * @param string $tweet The tweet to validate.
    * @return  int  the length of a tweet.
    */
-  public function getTweetLength($tweet = null) {
+  public function getTweetLength($tweet = null, $encoding = 'UTF-8') {
     if (is_null($tweet)) {
       $tweet = $this->tweet;
     }
-    $length = mb_strlen($tweet);
+    $length = mb_strlen($tweet, $encoding);
     $urls_with_indices = $this->extractor->extractURLsWithIndices($tweet);
     foreach ($urls_with_indices as $x) {
       $length += $x['indices'][0] - $x['indices'][1];


### PR DESCRIPTION
As mb_strlen() relies on mb_internal_encoding() to set encoding, length is not properly calculated in case internal encoding is not 'UTF-8'

I detected this bug on a XAMPP environment
