### PR TITLE
Updated `valid_url_preceding_chars` regular expression

### DIFF
--- a/lib/Twitter/Regex.php
+++ b/lib/Twitter/Regex.php
@@ -226,7 +226,7 @@ abstract class Twitter_Regex {
 
     # URL related hash regex collection
 
-    $tmp['valid_url_preceding_chars'] = '(?:[^A-Z0-9_'.$tmp['at_signs'].'\$'.$tmp['hash_signs'].'\.'.$tmp['invalid_characters'].']|^)';
+    $tmp['valid_url_preceding_chars'] = '(?:[^A-Z0-9_'.$tmp['at_signs'].'\$'.$tmp['hash_signs'].$tmp['invalid_characters'].']|^)';
 
     $tmp['domain_valid_chars'] = '[0-9a-z'.$tmp['latin_accents'].']';
     $tmp['valid_subdomain'] = '(?:(?:'.$tmp['domain_valid_chars'].'(?:[_-]|'.$tmp['domain_valid_chars'].')*)?'.$tmp['domain_valid_chars'].'\.)';

--- a/tests/Twitter/ExtractorTest.php
+++ b/tests/Twitter/ExtractorTest.php
@@ -231,6 +231,11 @@ class Twitter_ExtractorTest extends PHPUnit_Framework_TestCase {
     $extracted = Twitter_Extractor::create('text: example.com')->extractUrlWithoutProtocol(false)->extractURLsWithIndices();
     $this->assertSame(array(), $extracted, 'Unextract url without protocol');
   }
+
+  public function testExtractURLsPrecededByEllipsis() {
+    $extracted = Twitter_Extractor::create('text: ...http://www.example.com')->extractURLs();
+    $this->assertSame(array('http://www.example.com'), $extracted, 'Unextract url preceded by ellipsis');
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
Regular expression in `twitter/twitter-text` repo allows URLs to be preceded by dot.
