### PR TITLE
Avoid distributing tests & other unnecessary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 # Normalise line endings:
 * eol=lf
 
-# Prevent certain files from being exported:
-.gitattributes  export-ignore
-.gitignore      export-ignore
+# Prevent certain files and folders from being exported:
+tests/           export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.travis.yml      export-ignore
+phpunit.xml.dist export-ignore
+TODO             export-ignore


### PR DESCRIPTION
When relying on a stable version of this package in another project, one currently ends up pulling a few files that are not really needed in a production environment.

I'd like to propose that we prevent such files from being distributed.

Thank you!