### PR TITLE
HitHighlighter Class: avoid PHP 8 errors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 3.1.2
+
+- Hit highlighting: avoid errors with PHP 8.
+
 ## 3.0.0
 
 - Pass twitter-text conformance 3.0.0

--- a/lib/Twitter/Text/HitHighlighter.php
+++ b/lib/Twitter/Text/HitHighlighter.php
@@ -141,7 +141,7 @@ class HitHighlighter
             $offset = 0;
             $start_in_chunk = false;
             # Flatten the multidimensional hits array:
-            $hits_flat = array_merge(...array_values($hits));
+            $hits_flat = call_user_func_array('array_merge', array_values($hits));
             $hits_flat_count = count($hits_flat);
             # Loop over the hit indices:
             for ($index = 0; $index < $hits_flat_count; $index++) {

--- a/lib/Twitter/Text/HitHighlighter.php
+++ b/lib/Twitter/Text/HitHighlighter.php
@@ -141,7 +141,7 @@ class HitHighlighter
             $offset = 0;
             $start_in_chunk = false;
             # Flatten the multidimensional hits array:
-            $hits_flat = call_user_func_array('array_merge', $hits);
+            $hits_flat = array_merge(...array_values($hits));
             $hits_flat_count = count($hits_flat);
             # Loop over the hit indices:
             for ($index = 0; $index < $hits_flat_count; $index++) {


### PR DESCRIPTION
This change should avoid such errors:
`PHP Fatal error: Uncaught ArgumentCountError: array_merge() does not accept unknown named parameters`

`call_user_func_array()` expects a function name and an array of parameters to be unpacked and passed on to the function.
In PHP 8, when `call_user_func_array()` receives an array of parameters with string keys, the keys will be interpreted as parameter names.