### PR TITLE
Setters for url functions

### DIFF
--- a/lib/Twitter/Text/Autolink.php
+++ b/lib/Twitter/Text/Autolink.php
@@ -921,6 +921,94 @@ class Autolink
     }
 
     /**
+     * Get URL base for usernames
+     * @return string
+     */
+    public function getUrlBaseUser()
+    {
+        return $this->url_base_user;
+    }
+
+    /**
+     * Set the URL base for usernames
+     *
+     * @param string $url
+     * @return $this
+     */
+    public function setUrlBaseUser($url)
+    {
+        $this->url_base_user = $url;
+
+        return $this;
+    }
+
+    /**
+     * Get URL base for list links
+     * @return string
+     */
+    public function getUrlBaseList()
+    {
+        return $this->url_base_list;
+    }
+
+    /**
+     * Set the URL base for list links
+     *
+     * @param string $url
+     * @return $this
+     */
+    public function setUrlBaseList($url)
+    {
+        $this->url_base_list = $url;
+
+        return $this;
+    }
+
+    /**
+     * Get URL base for hashtags links
+     * @return string
+     */
+    public function getUrlBaseHash()
+    {
+        return $this->url_base_hash;
+    }
+
+    /**
+     * Set the URL base for hashtags links
+     *
+     * @param string $url
+     * @return $this
+     */
+    public function setUrlBaseHash($url)
+    {
+        $this->url_base_hash = $url;
+
+        return $this;
+    }
+
+    /**
+     * Get URL base for cashtags links
+     * @return string
+     */
+    public function getUrlBaseCash()
+    {
+        return $this->url_base_cash;
+    }
+
+    /**
+     * Set the URL base for cashtags links
+     *
+     * @param string $url
+     * @return $this
+     */
+    public function setUrlBaseCash($url)
+    {
+        $this->url_base_cash = $url;
+
+        return $this;
+    }
+
+    /**
      * html escape
      *
      * @param string $text

--- a/tests/TestCase/AutolinkTest.php
+++ b/tests/TestCase/AutolinkTest.php
@@ -216,4 +216,77 @@ class AutolinkTest extends TestCase
         $this->assertSame('my-hashtag-class', $this->linker->getHashtagClass(), 'getHashtagClass will return specific class');
         $this->assertSame('my-cashtag-class', $this->linker->getCashtagClass(), 'getCashtagClass will return specific class');
     }
+
+    public function testSetCustomUrlBase()
+    {
+        $this->assertSame('https://twitter.com/', $this->linker->getUrlBaseUser());
+        $this->assertSame('https://twitter.com/', $this->linker->getUrlBaseList());
+        $this->assertSame('https://twitter.com/search?q=%23', $this->linker->getUrlBaseHash());
+        $this->assertSame('https://twitter.com/search?q=%24', $this->linker->getUrlBaseCash());
+
+        // Override URLs
+        $baseUrl = 'https://example.com';
+        $expectedUserUrl = $baseUrl . '/user/';
+        $expectedListUrl = $baseUrl . '/list/';
+        $expectedHashUrl = $baseUrl . '/hash/';
+        $expectedCashUrl = $baseUrl . '/cash/';
+        $this->linker->setUrlBaseUser($expectedUserUrl);
+        $this->linker->setUrlBaseList($expectedListUrl);
+        $this->linker->setUrlBaseHash($expectedHashUrl);
+        $this->linker->setUrlBaseCash($expectedCashUrl);
+
+        $this->assertSame($expectedUserUrl, $this->linker->getUrlBaseUser(), 'getUrlBaseUser will return custom url base');
+        $this->assertSame($expectedListUrl, $this->linker->getUrlBaseList(), 'getUrlBaseList will return custom url base');
+        $this->assertSame($expectedHashUrl, $this->linker->getUrlBaseHash(), 'getUrlBaseHash will return custom url base');
+        $this->assertSame($expectedCashUrl, $this->linker->getUrlBaseCash(), 'getUrlBaseCash will return custom url base');
+    }
+
+    public function testSetUrlBaseUser()
+    {
+        $this->linker->setUrlBaseUser('https://example.com/user/');
+
+        $tweet = '@ummjackson 🤡 https://i.imgur.com/I32CQ81.jpg';
+        // @codingStandardsIgnoreStart
+        $expected = '@<a class="tweet-url username" href="https://example.com/user/ummjackson" rel="external nofollow" target="_blank">ummjackson</a> 🤡 <a href="https://i.imgur.com/I32CQ81.jpg" rel="external nofollow" target="_blank">https://i.imgur.com/I32CQ81.jpg</a>';
+        // @codingStandardsIgnoreEnd
+
+        $linkedText = $this->linker->autoLink($tweet);
+        $this->assertSame($expected, $linkedText);
+    }
+
+    public function testSetUrlBaseList()
+    {
+        $tweet = 'Testing @mention/list';
+        // @codingStandardsIgnoreStart
+        $expected = 'Testing @<a class="tweet-url list-slug" href="https://example.com/list/mention/list" rel="external nofollow" target="_blank">mention/list</a>';
+        // @codingStandardsIgnoreEnd
+
+        $this->linker->setUrlBaseList('https://example.com/list/');
+        $linkedText = $this->linker->autoLink($tweet);
+        $this->assertSame($expected, $linkedText);
+    }
+
+    public function testSetUrlBaseHash()
+    {
+        $tweet = 'Testing #hashtags';
+        // @codingStandardsIgnoreStart
+        $expected = 'Testing <a href="https://example.com/hash/hashtags" title="#hashtags" class="tweet-url hashtag" rel="external nofollow" target="_blank">#hashtags</a>';
+        // @codingStandardsIgnoreEnd
+
+        $this->linker->setUrlBaseHash('https://example.com/hash/');
+        $linkedText = $this->linker->autoLink($tweet);
+        $this->assertSame($expected, $linkedText);
+    }
+
+    public function testSetUrlBaseCash()
+    {
+        $tweet = 'Testing $APPL';
+        // @codingStandardsIgnoreStart
+        $expected = 'Testing <a href="https://example.com/cash/APPL" title="$APPL" class="tweet-url cashtag" rel="external nofollow" target="_blank">$APPL</a>';
+        // @codingStandardsIgnoreEnd
+
+        $this->linker->setUrlBaseCash('https://example.com/cash/');
+        $linkedText = $this->linker->autoLinkCashtags($tweet);
+        $this->assertSame($expected, $linkedText);
+    }
 }

--- a/tests/TestCase/AutolinkTest.php
+++ b/tests/TestCase/AutolinkTest.php
@@ -23,6 +23,9 @@ use Twitter\Text\Autolink;
  */
 class AutolinkTest extends TestCase
 {
+    /** @var Autolink $linker */
+    private $linker;
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
As commented on #44 , this PR adds setter functions for the base url variables allowing for URLs different than Twitter to be used with this library.