### PR TITLE
Don't count carriage return characters in end of line sequence

### DIFF
--- a/lib/Twitter/Text/Parser.php
+++ b/lib/Twitter/Text/Parser.php
@@ -61,6 +61,7 @@ class Parser
             return new ParseResults();
         }
 
+        $tweet = StringUtils::normalizeLineFeed($tweet);
         $normalizedTweet = StringUtils::normalizeFromNFC($tweet);
         $normalizedTweetLength = StringUtils::strlen($normalizedTweet);
 

--- a/lib/Twitter/Text/StringUtils.php
+++ b/lib/Twitter/Text/StringUtils.php
@@ -178,4 +178,13 @@ class StringUtils
 
         return $count;
     }
+
+    /**
+     * @param string $string
+     * @return string
+     */
+    public static function normalizeLineFeed(string $string): string
+    {
+        return str_replace("\r\n", "\n", $string);
+    }
 }

--- a/tests/TestCase/ParserTest.php
+++ b/tests/TestCase/ParserTest.php
@@ -243,4 +243,24 @@ class ParserTest extends TestCase
         $this->assertSame(0, $result->validRangeStart);
         $this->assertSame(1, $result->validRangeEnd);
     }
+
+    /**
+     * test for parseTweet with Carriage Return characters
+     */
+    public function testParseTweetWithCarriageReturn(): void
+    {
+        // @codingStandardsIgnoreStart
+        $text = "We're expanding the character limit! We want it to be easier and faster for everyone to express themselves.\r\n\r\nMore characters. More expression. More of what's happening.\r\nhttps://cards.twitter.com/cards/gsby/4ztbu";
+        // @codingStandardsIgnoreEnd
+        $result = $this->parser->parseTweet($text);
+
+        $this->assertInstanceOf('\Twitter\Text\ParseResults', $result);
+        $this->assertSame(192, $result->weightedLength);
+        $this->assertSame(685, $result->permillage);
+        $this->assertSame(true, $result->valid);
+        $this->assertSame(0, $result->displayRangeStart);
+        $this->assertSame(210, $result->displayRangeEnd);
+        $this->assertSame(0, $result->validRangeStart);
+        $this->assertSame(210, $result->validRangeEnd);
+    }
 }

--- a/tests/TestCase/StringUtilsTest.php
+++ b/tests/TestCase/StringUtilsTest.php
@@ -39,4 +39,15 @@ class StringUtilsTest extends TestCase
         $this->assertSame(4, StringUtils::charCount('🧕🏾'), 'U+1F9D5 U+1F3FE woman with headscarf with medium-dark skin tone has 4 code point');
         $this->assertSame(14, StringUtils::charCount('🏴󠁧󠁢󠁥󠁮󠁧󠁿'), 'flag (England) has 14 code point');
     }
+
+    /**
+     * Test for strip carriage return characters
+     *
+     * @return void
+     */
+    public function testNormalizeLineFeed(): void
+    {
+        $this->assertSame("foo\nbar\n", StringUtils::normalizeLineFeed("foo\r\nbar\r\n"), "Strip CR and leave LF");
+        $this->assertSame("foo\rbar", StringUtils::normalizeLineFeed("foo\rbar"), "Do not strip CR only");
+    }
 }


### PR DESCRIPTION
See also #46 and https://github.com/twitter/twitter-text/issues/8